### PR TITLE
Fix PHP 8.4 deprecation in \easybill\SDK\Client::request

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -30,7 +30,7 @@ class Client
     /**
      * @return mixed|string
      */
-    public function request(string $method, string $uri = '', array $body = null, bool $raw = false)
+    public function request(string $method, string $uri = '', ?array $body = null, bool $raw = false)
     {
         $request = new Request(
             $method,


### PR DESCRIPTION
Issue: https://github.com/easybill/php-sdk/issues/16

Due to changes in PHP 8.4, PHP will emit deprecation warnings if a parameters is initialised with NULL but the Type-Signature does not reflect on that. 